### PR TITLE
访问日志按路由筛选功能 Bug 修复

### DIFF
--- a/page/console.php
+++ b/page/console.php
@@ -337,6 +337,7 @@ $(document).ready(function() {
     $filterSelect.on('change', function() {
         $ipInput.removeAttr('placeholder').val('').hide();
         $cidSelect.hide();
+        $pathInput.removeAttr('placeholder').val('').hide();
 
         switch ($filterSelect.val()) {
             case 'ip':


### PR DESCRIPTION
访问日志筛选功能，选择“按路由”后再选择其它类型，路由 input 不消失

先选择按路由
<img width="342" alt="2018-01-26_110005" src="https://user-images.githubusercontent.com/27559529/35423494-fcdefd02-0288-11e8-90ec-1a8584a4a30e.png">
再选择按IP
<img width="478" alt="2018-01-26_110114" src="https://user-images.githubusercontent.com/27559529/35423501-05cae7dc-0289-11e8-8ab4-741a49a583c6.png">
