### PR TITLE
修复访问日志中受访地址和IP地址[ ? ]对应链接 Bug

### DIFF
--- a/page/console.php
+++ b/page/console.php
@@ -94,9 +94,9 @@ $access = new Access_Core();
                             <?php foreach ($access->logs['list'] as $log): ?>
                             <tr id="<?php echo $log['id']; ?>" data-id="<?php echo $log['id']; ?>">
                                 <td><input type="checkbox" data-id="<?php echo $log['id']; ?>" value="<?php echo $log['id']; ?>" name="id[]"/></td>
-                                <td><a target="_self" href="<?php $options->adminUrl('extending.php?panel=' . Access_Plugin::$panel . '&filter=path&path=' . $log['path']); ?>"><?php echo urldecode(str_replace("%23", "#", $log['url'])); ?></a></td>
+                                <td><a target="_self" href="<?php $options->adminUrl('extending.php?panel=' . Access_Plugin::$panel . '&filter=path&path=' . $log['path'] . '&type='. $request->type); ?>"><?php echo urldecode(str_replace("%23", "#", $log['url'])); ?></a></td>
                                 <td><a data-action="ua" href="#" title="<?php echo $log['ua'];?>"><?php echo $log['display_name']; ?></a></td>
-                                <td><a data-action="ip" data-ip="<?php echo long2ip($log['ip']); ?>" href="#"><?php echo long2ip($log['ip']); ?></a><?php if($request->filter != 'ip'): ?> <a target="_self" href="<?php $options->adminUrl('extending.php?panel=' . Access_Plugin::$panel . '&filter=ip&ip=' . long2ip($log['ip'])); ?>">[ ? ]</a><?php endif; ?></td>
+                                <td><a data-action="ip" data-ip="<?php echo long2ip($log['ip']); ?>" href="#"><?php echo long2ip($log['ip']); ?></a><?php if($request->filter != 'ip'): ?> <a target="_self" href="<?php $options->adminUrl('extending.php?panel=' . Access_Plugin::$panel . '&filter=ip&ip=' . long2ip($log['ip']) . '&type='. $request->type); ?>">[ ? ]</a><?php endif; ?></td>
                                 <td><a target="_blank" data-action="referer" href="<?php echo $log['referer']; ?>"><?php echo $log['referer']; ?></a></td>
                                 <td><?php echo date('Y-m-d H:i:s',$log['time']); ?></td>
                             </tr>


### PR DESCRIPTION
因链接地址缺少 type 参数，点击访问日志中受访地址链接或IP地址[ ? ]链接后，筛选后的详情页面中类型恢复为“默认(仅人类)”。此种情况下，会发生查询不到“仅爬虫”类的访问记录筛选后的详细信息，需要选择“仅爬虫”类后再筛选才可以。

1. 通过“仅爬虫”类筛选，点击[ ? ]进一步筛选
<img width="873" alt="2018-01-26_141418" src="https://user-images.githubusercontent.com/27559529/35427684-ea9c7c1a-02a5-11e8-87a9-d380b303bbf0.png">
2. 因类型恢复默认查询不到记录
<img width="882" alt="2018-01-26_141741" src="https://user-images.githubusercontent.com/27559529/35427689-eedba18e-02a5-11e8-9b50-fbe23f5529f0.png">
3. 接着重新选择“仅爬虫”类才可以查询到记录
<img width="882" alt="2018-01-26_141906" src="https://user-images.githubusercontent.com/27559529/35427691-f21f9e90-02a5-11e8-981a-58fd5e2c9257.png">

