### PR TITLE
修复 UA 字段问题

### DIFF
--- a/sql/Mysql.sql
+++ b/sql/Mysql.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `typecho_access_log` (
   `id`                int(10) unsigned NOT NULL auto_increment,
-  `ua`                varchar(255)     default ''  ,
+  `ua`                varchar(512)     default ''  ,
   `browser_id`        varchar(32)      default ''  ,
   `browser_version`   varchar(32)      default ''  ,
   `os_id`             varchar(32)      default ''  ,

--- a/sql/SQLite.sql
+++ b/sql/SQLite.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `typecho_access_log` (
   `id`                INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  `ua`                varchar(255)     default ''  ,
+  `ua`                varchar(512)     default ''  ,
   `browser_id`        varchar(32)      default ''  ,
   `browser_version`   varchar(32)      default ''  ,
   `os_id`             varchar(32)      default ''  ,


### PR DESCRIPTION
修复 UA 字段过短导致腾讯系浏览器访问后导致 500 报错的问题（https://paugram.com/coding/fix-typecho-ua-problem.html）