### PR TITLE
修复访问概览显示 调用未定义的函数 cal_days_in_month()

### DIFF
--- a/Access_Core.php
+++ b/Access_Core.php
@@ -253,7 +253,7 @@ class Access_Core
             } elseif($type == 'month') {
 		        $year = date('Y');
                 $month = date("m");
-                $monthDays = cal_days_in_month(CAL_GREGORIAN, intval($month), intval($year)); # 计算当月天数
+                $monthDays = date('t', mktime(0, 0, 0, $month, 1, $year));  # 计算当月天数
                 $this->overview[$type]['time'] = $month;
 
                 # 按天统计数据

--- a/Plugin.php
+++ b/Plugin.php
@@ -22,7 +22,7 @@ class Access_Plugin implements Typecho_Plugin_Interface
     public static function activate()
     {
         $msg = Access_Plugin::install();
-        Helper::addPanel(1, self::$panel, _t('Access控制台'), _t('Access插件控制台'), 'subscriber');
+        Helper::addPanel(1, self::$panel, _t('Access控制台'), _t('Access插件控制台'), 'administrator');
         Helper::addRoute("access_track_gif", "/access/log/track.gif", "Access_Action", 'writeLogs');
         Helper::addRoute("access_ip", "/access/ip.json", "Access_Action", 'ip');
         Helper::addRoute("access_delete_logs", "/access/log/delete.json", "Access_Action", 'deleteLogs');


### PR DESCRIPTION
修复访问概览显示 Call to undefined function cal_days_in_month()，造成无法显示访问概览，应该就不需要Calendar扩展了【网上找到的方法，自测可用】